### PR TITLE
Bugfix/get user profile

### DIFF
--- a/project/backend/controllers/authControllers.js
+++ b/project/backend/controllers/authControllers.js
@@ -1,4 +1,5 @@
 import * as authServices from '../database/services/authServices.js';
+import * as userServices from '../database/services/userServices.js';
 import { handleError } from '../utils/utils.js';
 import jwt from 'jsonwebtoken';
 import bcrypt from 'bcrypt';
@@ -46,6 +47,9 @@ const loginHandler = async (request, reply) => {
   return reply.status(200).send({
     message: 'Login successful',
     token,
+    username: user.username,
+    email: user.email,
+    avatar: user.avatar,
   });
 };
 
@@ -71,7 +75,12 @@ const registerHandler = async (request, reply) => {
     if (!registerUser) {
       return handleError(reply, new Error('Registration failed'), 500);
     }
-    return reply.status(201).send({ message: 'Registration successful' });
+    return reply.status(201).send({
+      message: 'Registration successful',
+      username: registerUser.username,
+      email: registerUser.email,
+      avatar: registerUser.avatar,
+    });
   } catch (error) {
     console.error('Registration error:', error);
     return handleError(reply, new Error('Registration failed'), 500);
@@ -91,12 +100,11 @@ const verificationHandler = async (request, reply) => {
   }
   try {
     const decoded = jwt.verify(token, JWT_SECRET);
-    const user = await authServices.checkCredentials(decoded.email);
+    const user = await userServices.getUserById(decoded.userId);
     if (!user) {
       return handleError(reply, new Error('Invalid credentials'), 401);
     }
-    let username = user.username;
-    reply.send({ user: decoded, username });
+    reply.send({ username: user.username, email: user.email, avatar: user.avatar });
   } catch (error) {
     return handleError(reply, error, 401);
   }

--- a/project/backend/controllers/userControllers.js
+++ b/project/backend/controllers/userControllers.js
@@ -31,8 +31,8 @@ const getAllUsersHandler = async (request, reply) => {
 // return user information, excluding email and password
 const getUserProfileHandler = async (request, reply) => {
   try {
-    const { userName } = request.body;
-    const user = userServices.getUserByUsername(userName);
+    const { userName } = request.query;
+    const user = await userServices.getUserByUsername(userName);
     if (!user) {
       return reply.status(404).send({ error: 'User not found' });
     }


### PR DESCRIPTION
Updated the get user profile API call to use query parameters instead of the request body.
Now, getting a users profiule is done by fetch https://localhost:3000/api/view_user_profile?userName=[username(f.e. djoyke)]

Readded cookies to register API call, on request of Djoyke

Added username, avatar and email to the response of the authentication API calls (login, register and authenticate), so frontend can use them right away for their shenanigans.