### PR TITLE
Fixed bug with requesting online friends

### DIFF
--- a/project/backend/routes/userRoutes.js
+++ b/project/backend/routes/userRoutes.js
@@ -2,6 +2,7 @@ import userControllers from '../controllers/userControllers.js';
 import authControllers from '../controllers/authControllers.js';
 import gameControllers from '../controllers/gameControllers.js';
 import { websocketHandler } from '../websocket/websocket.js';
+import { connectionManager } from '../websocket/managers/connectionManager.js';
 // import snake from '../plugins/websocketSnake.js';
 
 export default async function userRoutes(fastify) {
@@ -41,6 +42,12 @@ export default async function userRoutes(fastify) {
   //     { preHandler: authControllers.authenticate },
   //     userControllers.deteleFriendHandler,
   //   );
+
+  fastify.get(
+    '/api/get_online_friends',
+    { preHandler: authControllers.authenticate },
+    connectionManager.getOnlineFriendsHandler,
+  );
 
   // Websocket
   fastify.get('/ws/connect', { websocket: true }, websocketHandler);

--- a/project/backend/websocket/managers/connectionManager.js
+++ b/project/backend/websocket/managers/connectionManager.js
@@ -85,11 +85,7 @@ function updateUsernameInConnections(userId, newUsername) {
   });
 }
 
-async function getOnlineFriendsHandler(request, reply) {
-  const { username } = request.query;
-  if (!username) {
-    return reply.code(400).send({ error: 'Username is required' });
-  }
+async function getFriendNames(username) {
   const friends = await getFriends(username);
   if (!friends || friends.length === 0) {
     console.log(`No friends found for user: ${username}`);
@@ -101,7 +97,16 @@ async function getOnlineFriendsHandler(request, reply) {
       onlineFriends.push(friend.username);
     }
   });
-  return reply.code(200).send({ friends: onlineFriends });
+  return onlineFriends;
+}
+
+async function getOnlineFriendsHandler(request, reply) {
+  const { username } = request.query;
+  if (!username) {
+    return reply.code(400).send({ error: 'Username is required' });
+  }
+  const friendNames = await getFriendNames(username);
+  return reply.code(200).send({ friends: friendNames });
 }
 
 export const connectionManager = {
@@ -112,6 +117,7 @@ export const connectionManager = {
   getConnectedUsers,
   updateUsernameInConnections,
   getOnlineFriendsHandler,
+  getFriendNames,
   getUserNameById,
   getNamesOfConnectedUsers,
   printUsers,

--- a/project/backend/websocket/managers/connectionManager.js
+++ b/project/backend/websocket/managers/connectionManager.js
@@ -1,5 +1,7 @@
 // map that holds all the users, it connects their IDs to a set of their connections
 // a user can have multiple connections, think multiple browser tabs logged into the same account
+import { getFriends, getUserById } from '../../database/services/userServices.js';
+
 const connectedUsers = new Map();
 
 // function to add a connection (socket) to a user
@@ -83,6 +85,25 @@ function updateUsernameInConnections(userId, newUsername) {
   });
 }
 
+async function getOnlineFriendsHandler(request, reply) {
+  const { username } = request.query;
+  if (!username) {
+    return reply.code(400).send({ error: 'Username is required' });
+  }
+  const friends = await getFriends(username);
+  if (!friends || friends.length === 0) {
+    console.log(`No friends found for user: ${username}`);
+    return [];
+  }
+  const onlineFriends = [];
+  friends.forEach((friend) => {
+    if (connectionManager.getUserConnections(friend.userId) !== undefined) {
+      onlineFriends.push(friend.username);
+    }
+  });
+  return reply.code(200).send({ friends: onlineFriends });
+}
+
 export const connectionManager = {
   addConnection,
   removeConnection,
@@ -90,6 +111,7 @@ export const connectionManager = {
   getUserConnectionsBySession,
   getConnectedUsers,
   updateUsernameInConnections,
+  getOnlineFriendsHandler,
   getUserNameById,
   getNamesOfConnectedUsers,
   printUsers,

--- a/project/backend/websocket/managers/messageManager.js
+++ b/project/backend/websocket/managers/messageManager.js
@@ -79,23 +79,8 @@ function createBroadcast(message) {
   };
 }
 
-async function getFriendNames(username) {
-  const friends = await getFriends(username);
-  if (!friends || friends.length === 0) {
-    console.log(`No friends found for user: ${username}`);
-    return [];
-  }
-  const onlineFriends = [];
-  friends.forEach((friend) => {
-    if (connectionManager.getUserConnections(friend.userId) !== undefined) {
-      onlineFriends.push(friend.username);
-    }
-  });
-  return onlineFriends;
-}
-
 async function sendLoggedInFriends(connection) {
-  const friendNames = await getFriendNames(connection.username);
+  const friendNames = await connectionManager.getFriendNames(connection.username);
   createBroadcast({
     type: 'onlineFriends',
     friends: friendNames,

--- a/project/frontend/src/profile/profile.ts
+++ b/project/frontend/src/profile/profile.ts
@@ -170,7 +170,7 @@ export async function showFriends(username: string) {
     // Fetch profile + online list in parallel
     const [data, onlineFriends] = await Promise.all([
       fetchUserProfile(username),
-      globalSession.getOnlineFriends(),
+      globalSession.getOnlineFriends(username),
     ]);
 
     if (token !== friendsRenderToken) return;


### PR DESCRIPTION
Changed the way we get friends online status.
The request does not go through the websockets anymore, which was unreliable due to the possibility of them not being initialised. Instead we just use the ol reliable HTTP request to get the friends and await the response.

- added route in userRoutes for a GET request for onlineFriends
- added handler for said getRequest that uses the connected websockets and the database to get the required information on friends
- moved a function from messageManager.js to connectionManager.js since it makes more sense naming wise and to avoid code duplication
- changed the frontend getOnlineFriends function to use the newly created route
- adjusted the getOnlineFriends function to take a username of the person whose online friends we want to see. This way if we go to another person's profile in the frontend we can see their friends online status
- in profile.ts added the username to the function call